### PR TITLE
branch: lobby 페이지 및 하위 컴포넌트 lazy loading 적용

### DIFF
--- a/src/components/common/SuspenseWrapper.jsx
+++ b/src/components/common/SuspenseWrapper.jsx
@@ -1,0 +1,14 @@
+import React, { Suspense } from "react";
+
+// 공통 Suspense 래퍼 함수
+const SuspenseWrapper = (LazyComponent, fallback = <div>로딩 중...</div>) => {
+  return function WrappedComponent(props) {
+    return (
+      <Suspense fallback={fallback}>
+        <LazyComponent {...props} />
+      </Suspense>
+    );
+  };
+};
+
+export default SuspenseWrapper;

--- a/src/pages/game/game1/LazyGame1Page.jsx
+++ b/src/pages/game/game1/LazyGame1Page.jsx
@@ -1,0 +1,6 @@
+import SuspenseWrapper from "components/common/SuspenseWrapper";
+import { lazy } from "react";
+
+const Game1Page = lazy(() => import("pages/game/game1/Game1Page"));
+
+export default SuspenseWrapper(Game1Page);

--- a/src/pages/game/game2/LazyGame2Page.jsx
+++ b/src/pages/game/game2/LazyGame2Page.jsx
@@ -1,0 +1,6 @@
+import SuspenseWrapper from "components/common/SuspenseWrapper";
+import { lazy } from "react";
+
+const Game2Page = lazy(() => import("pages/game/game2/Game2Page"));
+
+export default SuspenseWrapper(Game2Page);

--- a/src/routes/lobby.js
+++ b/src/routes/lobby.js
@@ -1,13 +1,14 @@
-import WaitingRoom from "components/lobby/waiting/WaitingRoom";
-import Game1CreatePage from "pages/game/Game1CreatePage";
-import Game1LobbyPage from "pages/game/Game1LobbyPage";
-import Game2LobbyPage from "pages/game/Game2LobbyPage";
-import Game1Page from "pages/game/game1/Game1Page";
-import Game2Page from "pages/game/game2/Game2Page";
-import LobbyLayout, {
-  loader as lobbyLayoutLoader,
-} from "pages/lobby/LobbyLayout";
-import LobbyPage from "pages/lobby/LobbyPage";
+import { loader as lobbyLayoutLoader } from "pages/lobby/LobbyLayout";
+import { lazy } from "react";
+
+const LobbyLayout = lazy(() => import("pages/lobby/LobbyLayout"));
+const LobbyPage = lazy(() => import("pages/lobby/LobbyPage"));
+const Game1LobbyPage = lazy(() => import("pages/game/Game1LobbyPage"));
+const Game1CreatePage = lazy(() => import("pages/game/Game1CreatePage"));
+const Game2LobbyPage = lazy(() => import("pages/game/Game2LobbyPage"));
+const WaitingRoom = lazy(() => import("components/lobby/waiting/WaitingRoom"));
+const Game1Page = lazy(() => import("pages/game/game1/Game1Page"));
+const Game2Page = lazy(() => import("pages/game/game2/Game2Page"));
 
 const lobby = [
   {
@@ -43,10 +44,6 @@ const lobby = [
                 index: true,
                 element: <Game2LobbyPage />,
               },
-              // {
-              //   path: "create",
-              //   element: <Game1CreatePage />,
-              // },
             ],
           },
           {
@@ -62,7 +59,7 @@ const lobby = [
       {
         path: "play2",
         element: <Game2Page />,
-      }
+      },
     ],
   },
 ];

--- a/src/routes/lobby.js
+++ b/src/routes/lobby.js
@@ -1,14 +1,13 @@
-import { loader as lobbyLayoutLoader } from "pages/lobby/LobbyLayout";
-import { lazy } from "react";
-
-const LobbyLayout = lazy(() => import("pages/lobby/LobbyLayout"));
-const LobbyPage = lazy(() => import("pages/lobby/LobbyPage"));
-const Game1LobbyPage = lazy(() => import("pages/game/Game1LobbyPage"));
-const Game1CreatePage = lazy(() => import("pages/game/Game1CreatePage"));
-const Game2LobbyPage = lazy(() => import("pages/game/Game2LobbyPage"));
-const WaitingRoom = lazy(() => import("components/lobby/waiting/WaitingRoom"));
-const Game1Page = lazy(() => import("pages/game/game1/Game1Page"));
-const Game2Page = lazy(() => import("pages/game/game2/Game2Page"));
+import WaitingRoom from "components/lobby/waiting/WaitingRoom";
+import LazyGame1Page from "pages/game/game1/LazyGame1Page";
+import Game1CreatePage from "pages/game/Game1CreatePage";
+import Game1LobbyPage from "pages/game/Game1LobbyPage";
+import LazyGame2Page from "pages/game/game2/LazyGame2Page";
+import Game2LobbyPage from "pages/game/Game2LobbyPage";
+import LobbyLayout, {
+  loader as lobbyLayoutLoader,
+} from "pages/lobby/LobbyLayout";
+import LobbyPage from "pages/lobby/LobbyPage";
 
 const lobby = [
   {
@@ -54,11 +53,11 @@ const lobby = [
       },
       {
         path: "play",
-        element: <Game1Page />,
+        element: <LazyGame1Page />,
       },
       {
         path: "play2",
-        element: <Game2Page />,
+        element: <LazyGame2Page />,
       },
     ],
   },


### PR DESCRIPTION
# branch: lobby 페이지 및 하위 컴포넌트 lazy loading 적용

## 📝 개요

<!-- 작성 배경 -->
- 추후, 추가적인 게임 개발과 로직 추가로 번들의 크기가 커질 수 있다고 판단했습니다.
- 이에, code splitting을 활용하여 lobby페이지와 홈페이지의 번들을 분할하였습니다.
---

## ⚙️ 구현 내용

<!-- 구현한 내용 -->
- lobby 페이지 및 하위 컴포넌트 lazy loading 적용
---

## 📎 기타
- Suspense를 활용하여 로딩 상태를 나타내는 컴포넌트는 디자인의 부재로 보류하였습니다. (공식문서에는 Suspense를 권장하고 있습니다)
- webpack.config에서 output으로 각각의 lazy bundle의 이름을 설정할 수 있으나, production으로 빌드해본 결과 해시.js로 번들링이 되는 것을 확인하였습니다. 이 경우, 브라우저에서 변경 유무를 파악하며 캐싱을 할 수 있는 것으로 판단되기에 따로 output을 지정하지는 않았습니다.
- LobbyLayout에 Suspense를 적용하게 된다면 라우터에서 <Suspense><LobbyLayout/></Suspense> 로 감싸는 방식이나 래핑하는 파일(LazyLobbyLayout)을 추가적으로 구현해야 한다고 생각합니다. 전자로 하자니 라우터 코드가 지저분해질 것 같고, 후자로 하자니 파일의 depth가 커지는 것 같아 고민을 하였습니다. 좋은 방식이 있을까요?
---

## 🧪 테스트 결과
<!-- 참고 사항, 이슈, 고려했던 사항 등 -->
code splitting 전
<img width="1709" height="1011" alt="스크린샷 2025-07-25 오후 2 00 22" src="https://github.com/user-attachments/assets/010a390b-aad6-4555-9528-c9c28ff3025b" />

code splitting 후
<img width="1708" height="746" alt="스크린샷 2025-07-25 오후 11 57 07" src="https://github.com/user-attachments/assets/055adb05-c08a-4877-b945-3c704e100ea8" />

- js 파일 크기 494kb -> 442kb(약 10.5% 감소)
- Load time 165ms -> 121ms(약 26.7% 단축)
<!-- 테스트 내용 (선택) -->