### PR TITLE
fix: MacOS 환경에서 한글이 두 번 입력되는 현상 해결

### DIFF
--- a/src/components/lobby/LobbyChatting.jsx
+++ b/src/components/lobby/LobbyChatting.jsx
@@ -138,15 +138,12 @@ const LobbyChatting = ({
   }, 100);
 
   const handleKeyDown = (e) => {
-    if (e.key === "Enter") {
-      if (e.shiftKey) {
-        return;
-      } else {
-        e.preventDefault();
-        handleSendMessage();
-      }
+    if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      handleSendMessage();
     }
   };
+
   return (
     <div className="lobby-chatting-container">
       <img

--- a/src/components/lobby/LobbyChatting.jsx
+++ b/src/components/lobby/LobbyChatting.jsx
@@ -138,6 +138,7 @@ const LobbyChatting = ({
   }, 100);
 
   const handleKeyDown = (e) => {
+    if (e.shiftKey) return;
     if (e.key === "Enter" && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSendMessage();


### PR DESCRIPTION
# PR 제목
fix: MacOS + Chrome 환경에서 한글이 두 번 입력되는 현상 해결
## 📝 개요

<!-- 작성 배경 -->
- https://tony1724.tistory.com/28 블로그에 정리해두었습니다~
---

## ⚙️ 구현 내용

<!-- 구현한 내용 -->
- e.nativeEvent.isComposing 프로퍼티를 추가적으로 비교하여, 엔터입력 시 1회만 한글이 전송되도록 하였습니다.
---

## 📎 기타

<!-- 참고 사항, 이슈, 고려했던 사항 등 -->

---


## 🧪 테스트 결과
<img width="195" height="396" alt="스크린샷 2025-08-15 오후 1 44 52" src="https://github.com/user-attachments/assets/46511d3f-5ab3-4f62-be6a-b9884360f391" />

<!-- 테스트 내용 (선택) -->