### PR TITLE
refactor: 스크롤 탑 리팩토링

### DIFF
--- a/src/components/common/ScrollToTop.jsx
+++ b/src/components/common/ScrollToTop.jsx
@@ -3,8 +3,12 @@ import { useLocation } from "react-router-dom";
 
 const ScrollToTop = () => {
   const { pathname } = useLocation();
-
   useEffect(() => {
+    const rootContainer = document.querySelector(".root-layout-container");
+    if (rootContainer) {
+      rootContainer.scrollTo(0, 0);
+    }
+
     window.scrollTo(0, 0);
   }, [pathname]);
 


### PR DESCRIPTION
## 배경 (Background) 
기존에는 페이지 라우팅(pathname 변경) 시 window.scrollTo(0, 0)만 동작하고 있었습니다. 하지만 현재 프로젝트의 레이아웃 구조상 스크롤이 body나 window가 아닌 특정 레이아웃 컨테이너(.root-layout-container) 내부에서 발생하고 있어, 페이지를 이동해도 이전 스크롤 위치가 그대로 유지되는 문제가 있었습니다.

## 작업 내용 (Changes) 
ScrollToTop 컴포넌트의 로직을 개선했습니다.
useEffect 내에서 .root-layout-container 요소를 직접 조회합니다.
해당 컨테이너가 존재할 경우 scrollTo(0, 0)을 실행하여 최상단으로 이동시킵니다.
기존의 window.scrollTo(0, 0) 로직도 혹시 모를 상황을 대비해 유지했습니다.

## 테스트 방법 (Test Plan)

헤더나 소개 preview 컴포넌트를 통해 소개 페이지로 이동합니다.
이동한 페이지에서 스크롤이 최상단(0, 0)에 위치하는지 확인합니다.